### PR TITLE
Text collection verse display changed to use plain text instead of usfm

### DIFF
--- a/src/paratext-bible-text-collection/src/util.ts
+++ b/src/paratext-bible-text-collection/src/util.ts
@@ -8,7 +8,7 @@ export type ProjectInfo = { id: string; name: string };
  * these
  */
 export const REQUIRED_PROJECT_INTERFACES: ProjectInterfaces[] = [
-  'platformScripture.USFM_Verse',
+  'platformScripture.PlainText_Verse',
   'platformScripture.USJ_Chapter',
 ];
 

--- a/src/paratext-bible-text-collection/src/web-views/components/verse-display.component.tsx
+++ b/src/paratext-bible-text-collection/src/web-views/components/verse-display.component.tsx
@@ -43,10 +43,10 @@ function VerseDisplay({
   isSelected,
   useWebViewState,
 }: VerseDisplayProps) {
-  const [usfm] = useProjectData('platformScripture.USFM_Verse', projectId).VerseUSFM(
-    verseRef,
-    'Loading',
-  );
+  const [versePlainText] = useProjectData(
+    'platformScripture.PlainText_Verse',
+    projectId,
+  ).VersePlainText(verseRef, '');
   const [fontSize, setFontSize] = useWebViewState<number>(`fontSize_${projectId}`, defaultFontSize);
   const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
 
@@ -147,7 +147,7 @@ function VerseDisplay({
         </div>
       </div>
       <p className="text" style={{ fontSize }}>
-        {usfm}
+        {versePlainText}
       </p>
     </div>
   );


### PR DESCRIPTION
https://github.com/paranext/paranext-core/issues/1111

![image](https://github.com/user-attachments/assets/f17f5a04-c59c-4ed4-8cc8-0be55e5f3ed2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/35)
<!-- Reviewable:end -->
