### PR TITLE
Fix improper papi frontend import from a non webview file

### DIFF
--- a/src/paratext-bible-text-collection/src/main.ts
+++ b/src/paratext-bible-text-collection/src/main.ts
@@ -6,7 +6,6 @@ import type {
   SavedWebViewDefinition,
   WebViewDefinition,
 } from '@papi/core';
-import localizationService from '@papi/frontend';
 import { VerseRef } from '@sillsdev/scripture';
 import textCollectionReact from './web-views/paratext-text-collection.web-view?inline';
 import textCollectionReactStyles from './web-views/paratext-text-collection.web-view.scss?inline';
@@ -33,7 +32,7 @@ const textCollectionWebViewProvider: IWebViewProvider = {
 
     let localizedTextCollection: string | undefined;
     try {
-      localizedTextCollection = await localizationService.localization.getLocalizedString({
+      localizedTextCollection = await papi.localization.getLocalizedString({
         localizeKey: '%textCollection_defaultTitle%',
       });
     } catch (e) {

--- a/src/paratext-bible-word-list/src/main.ts
+++ b/src/paratext-bible-word-list/src/main.ts
@@ -13,7 +13,6 @@ import { VerseRef } from '@sillsdev/scripture';
 import type { WordListDataTypes, WordListEntry, WordListSelector } from 'paratext-bible-word-list';
 import { ScriptureReference } from 'platform-bible-react';
 import { formatReplacementString, UnsubscriberAsync } from 'platform-bible-utils';
-import localizationService from '@papi/frontend';
 import wordListReactStyles from './word-list.web-view.scss?inline';
 import wordListReact from './word-list.web-view?inline';
 
@@ -230,7 +229,7 @@ const wordListWebViewProvider: IWebViewProvider = {
     let localizedTitleWithProject: string;
     let localizedTitle: string;
     try {
-      const localizedStrings = await localizationService.localization.getLocalizedStrings({
+      const localizedStrings = await papi.localization.getLocalizedStrings({
         localizeKeys: [titleWithProjectFormatKey, titleKey],
       });
       localizedTitleWithProjectFormat = localizedStrings[titleWithProjectFormatKey];


### PR DESCRIPTION
@papi/frontend should not be imported from in a main file or anything else that is not the front end so fixed two places where that was happening in wordlist main and text collection main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/46)
<!-- Reviewable:end -->
