### PR TITLE
Add Spanish Localizations and bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jsonpath-plus": "^10.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-jsdoc": "^1.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1",
@@ -184,7 +185,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "async-mutex": "^0.4.1"
+        "async-mutex": "^0.4.1",
+        "jsonpath-plus": "^10.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.13",
@@ -23495,6 +23497,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jsonpath-plus": "^10.0.0",
         "lucide-react": "^0.452.0",
         "next-themes": "^0.3.0",
         "platform-bible-utils": "file:../platform-bible-utils",
@@ -23532,6 +23535,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
+        "jsonpath-plus": "^10.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-jsdoc": "^1.3.0",
         "stringz": "^2.1.0",

--- a/src/paratext-bible-text-collection/contributions/localizedStrings.json
+++ b/src/paratext-bible-text-collection/contributions/localizedStrings.json
@@ -16,6 +16,22 @@
       "%textCollection_verseDisplay_zoomOut%": "Zoom out",
       "%textCollection_verseDisplay_zoomReset%": "Zoom Reset",
       "%webview_selectProjects%": "Select projects"
+    },
+    "es": {
+      "%mainMenu_openTextCollection%": "Abrir Colección de Textos",
+      "%textCollection_defaultTitle%": "Colección de Textos",
+      "%textCollection_dialog_selectProjectsToOpen_prompt%": "Por favor, seleccione proyectos para abrir en el colección de textos:",
+      "%textCollection_dialog_selectProjectsToShow_prompt%": " Por favor, seleccione proyectos para mostrar en el colección de textos:",
+      "%textCollection_dialog_selectProjectsInTextCollection_title%": "seleccione proyectos en el colección de textos",
+      "%textCollection_dialog_openTextCollection_title%": "Abrir Colección de Textos",
+      "%textCollection_verseDisplay_projectNameMissing%": "...",
+      "%textCollection_verseDisplay_closeText%": "Cerrar Texto",
+      "%textCollection_verseDisplay_moveTextDown%": "Bajar",
+      "%textCollection_verseDisplay_moveTextUp%": "Subir",
+      "%textCollection_verseDisplay_zoomIn%": "Acercar",
+      "%textCollection_verseDisplay_zoomOut%": "Alejar",
+      "%textCollection_verseDisplay_zoomReset%": "Zoom Restablecer",
+      "%webview_selectProjects%": "Seleccione proyectos"
     }
   }
 }

--- a/src/paratext-bible-text-collection/src/web-views/components/verse-display.component.tsx
+++ b/src/paratext-bible-text-collection/src/web-views/components/verse-display.component.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'platform-bible-react';
-import { MouseEvent } from 'react';
+import { MouseEvent, useMemo } from 'react';
 import { ProjectInfo } from '../../util';
 
 const defaultFontSize: number = 16;
@@ -61,15 +61,20 @@ function VerseDisplay({
   const zoomResetKey = '%textCollection_verseDisplay_zoomReset%';
   const moveUpKey = '%textCollection_verseDisplay_moveTextUp%';
   const moveDownKey = '%textCollection_verseDisplay_moveTextDown%';
-  const [localizedStrings] = useLocalizedStrings([
-    ellipsisKey,
-    closeTextKey,
-    zoomInKey,
-    zoomOutKey,
-    zoomResetKey,
-    moveUpKey,
-    moveDownKey,
-  ]);
+  const [localizedStrings] = useLocalizedStrings(
+    useMemo(
+      () => [
+        ellipsisKey,
+        closeTextKey,
+        zoomInKey,
+        zoomOutKey,
+        zoomResetKey,
+        moveUpKey,
+        moveDownKey,
+      ],
+      [],
+    ),
+  );
   const localizedEllipsis = localizedStrings[ellipsisKey];
   const localizedCloseText = localizedStrings[closeTextKey];
   const localizedZoomIn = localizedStrings[zoomInKey];

--- a/src/paratext-bible-text-collection/src/web-views/paratext-text-collection.web-view.tsx
+++ b/src/paratext-bible-text-collection/src/web-views/paratext-text-collection.web-view.tsx
@@ -1,5 +1,5 @@
 import papi from '@papi/frontend';
-import { useDialogCallback } from '@papi/frontend/react';
+import { useDialogCallback, useLocalizedStrings } from '@papi/frontend/react';
 import { Fragment, useCallback, useEffect, useMemo } from 'react';
 import { Button, ScriptureReference, usePromise } from 'platform-bible-react';
 import { deepEqual } from 'platform-bible-utils';

--- a/src/paratext-bible-word-list/contributions/localizedStrings.json
+++ b/src/paratext-bible-word-list/contributions/localizedStrings.json
@@ -9,11 +9,27 @@
       "%wordList_openListForProject_prompt%": "Please select project to open in the word list:",
       "%wordList_openListForProject_title%": "Open Word List",
       "%wordList_partialWordCount_titleFormat%": "Words ({wordListLength} of {fullWordCount}) {sortingDirectionIcon}",
+      "%wordList_totalCount_titleFormat%": "Words ({fullWordCount})",
       "%wordList_tableView_label%": "Table",
       "%wordList_title_format%": "Word List {projectName}",
       "%wordList_titleWithProjectName_format%": "Word List for project {projectName}",
       "%wordList_view_label%": "view",
       "%wordList_wordCount_format%": "Count {sortingDirectionIcon}"
+    },
+    "es": {
+      "%mainMenu_openWordList%": "Abrir Lista de Palabras",
+      "%wordList_cloudView_label%": "Nube",
+      "%wordList_filter_defaultText%": "Filtro de palabra",
+      "%wordList_fullWordCount_titleFormat%": "Palabras ({fullWordCount}) \\{sortingDirectionIcon\\}",
+      "%wordList_openListForProject_prompt%": "Por favor, seleccione proyecto para abrir en la lista de palabras:",
+      "%wordList_openListForProject_title%": "Abrir Lista de Palabras",
+      "%wordList_partialWordCount_titleFormat%": "Palabras ({wordListLength} de {fullWordCount}) {sortingDirectionIcon}",
+      "%wordList_totalCount_titleFormat%": "Palabras ({fullWordCount})",
+      "%wordList_tableView_label%": "Tabla",
+      "%wordList_title_format%": "Lista de Palabras {projectName}",
+      "%wordList_titleWithProjectName_format%": "Lista de Palabras para el proyecto {projectName}",
+      "%wordList_view_label%": "vista",
+      "%wordList_wordCount_format%": "Conteo {sortingDirectionIcon}"
     }
   }
 }

--- a/src/paratext-bible-word-list/src/word-table.component.tsx
+++ b/src/paratext-bible-word-list/src/word-table.component.tsx
@@ -69,7 +69,7 @@ export default function WordTable({ wordList, fullWordCount, onWordClick }: Word
   };
 
   const [localizedStrings] = useLocalizedStrings(
-    useMemo(() => [countFormatKey, fullCountFormatKey], []),
+    useMemo(() => [countFormatKey, fullCountFormatKey, partialCountFormatKey], []),
   );
 
   const localizedCountFormat = localizedStrings[countFormatKey];


### PR DESCRIPTION
Add Spanish localizations for text collection and word list. Fix a missed import and an infinite rerender bug caused by not using useMemo on localized strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/47)
<!-- Reviewable:end -->
