### PR TITLE
PT-2992/PT-2993: No 'generating' spinner for empty word list

### DIFF
--- a/src/paratext-bible-word-list/src/word-list.web-view.tsx
+++ b/src/paratext-bible-word-list/src/word-list.web-view.tsx
@@ -94,7 +94,7 @@ globalThis.webViewComponent = function WordListWebView({
   }, [dataSelector, projectId, scope, scrRef]);
 
   useEffect(() => {
-    if (isPlatformError(wordList) || (wordList && wordList.length > 0)) {
+    if (isPlatformError(wordList) || (wordList && Array.isArray(wordList))) {
       setLoading(false);
     }
   }, [wordList]);


### PR DESCRIPTION
In the degenerate case of an empty word list,
e.g. when a verse does not (yet) have any words
and the word list for one verse is shown,
this properly distinguishes between the results
between 'no result (yet)' and 'zero words'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/76)
<!-- Reviewable:end -->
