### PR TITLE
Fix problems related to wordlist calc being fully synchronous

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       "devDependencies": {
         "electron-log": "^5.0.3",
         "escape-string-regexp": "^5.0.0",
-        "typescript": "5.4.5"
+        "typescript": "^5.8.3"
       }
     },
     "../paranext-core/lib/platform-bible-react": {
@@ -101,13 +101,17 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@biblionexus-foundation/platform-editor": "~0.7.12",
+        "@biblionexus-foundation/scripture-utilities": "~0.1.0",
         "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.3.1",
-        "@radix-ui/react-dialog": "^1.1.13",
+        "@radix-ui/react-context-menu": "^2.2.15",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-menubar": "^1.1.14",
         "@radix-ui/react-popover": "^1.1.13",
+        "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-radio-group": "^1.3.6",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-separator": "^1.1.6",
@@ -132,7 +136,8 @@
         "react-hotkeys-hook": "^4.6.1",
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.9",
@@ -140,9 +145,11 @@
         "@babel/preset-typescript": "^7.26.0",
         "@chromatic-com/storybook": "^4.0.0",
         "@senojs/rollup-plugin-style-inject": "^0.2.3",
-        "@storybook/addon-a11y": "^9.0.6",
-        "@storybook/addon-links": "^9.0.6",
-        "@storybook/react-vite": "^9.0.6",
+        "@storybook/addon-a11y": "9.0.17",
+        "@storybook/addon-docs": "9.0.17",
+        "@storybook/addon-links": "9.0.17",
+        "@storybook/addon-vitest": "9.0.17",
+        "@storybook/react-vite": "9.0.17",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -154,17 +161,25 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react-swc": "^3.8.0",
+        "@vitest/browser": "^3.2.4",
+        "@vitest/coverage-v8": "^3.2.4",
         "axe-playwright": "^2.1.0",
         "dts-bundle-generator": "^9.5.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.3",
-        "eslint-plugin-storybook": "^9.0.6",
+        "eslint-plugin-storybook": "9.0.17",
         "jsonpath-plus": "^10.3.0",
+        "playwright": "^1.54.1",
         "prettier": "^3.5.2",
         "prettier-plugin-jsdoc": "^1.3.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
-        "storybook": "^9.0.5",
+        "remark-cli": "^12.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-mdx": "^3.1.0",
+        "storybook": "9.0.17",
+        "storybook-addon-code-editor": "^5.0.0",
+        "storybook-addon-rtl": "^2.0.0",
         "stylelint": "^16.11.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-sass-guidelines": "^12.1.0",
@@ -176,7 +191,7 @@
         "typescript": "^5.8.3",
         "vite": "^6.3.4",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.7"
+        "vitest": "^3.2.4"
       },
       "peerDependencies": {
         "react": ">=18.3.1",
@@ -207,7 +222,7 @@
         "typedoc": "^0.28.3",
         "typescript": "^5.8.3",
         "vite": "^6.3.4",
-        "vitest": "^3.0.7"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -22847,7 +22862,7 @@
         "electron-log": "^5.0.3",
         "escape-string-regexp": "^5.0.0",
         "platform-bible-utils": "file:../platform-bible-utils",
-        "typescript": "5.4.5"
+        "typescript": "^5.8.3"
       }
     },
     "paratext-bible-text-collection": {
@@ -23122,14 +23137,18 @@
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.26.0",
+        "@biblionexus-foundation/platform-editor": "~0.7.12",
+        "@biblionexus-foundation/scripture-utilities": "~0.1.0",
         "@chromatic-com/storybook": "^4.0.0",
         "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.3.1",
-        "@radix-ui/react-dialog": "^1.1.13",
+        "@radix-ui/react-context-menu": "^2.2.15",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-menubar": "^1.1.14",
         "@radix-ui/react-popover": "^1.1.13",
+        "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-radio-group": "^1.3.6",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-separator": "^1.1.6",
@@ -23142,9 +23161,11 @@
         "@radix-ui/react-toggle-group": "^1.1.9",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@senojs/rollup-plugin-style-inject": "^0.2.3",
-        "@storybook/addon-a11y": "^9.0.6",
-        "@storybook/addon-links": "^9.0.6",
-        "@storybook/react-vite": "^9.0.6",
+        "@storybook/addon-a11y": "9.0.17",
+        "@storybook/addon-docs": "9.0.17",
+        "@storybook/addon-links": "9.0.17",
+        "@storybook/addon-vitest": "9.0.17",
+        "@storybook/react-vite": "9.0.17",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-table": "^8.21.3",
@@ -23158,6 +23179,8 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react-swc": "^3.8.0",
+        "@vitest/browser": "^3.2.4",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.20",
         "axe-playwright": "^2.1.0",
         "class-variance-authority": "^0.7.1",
@@ -23167,18 +23190,24 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.3",
-        "eslint-plugin-storybook": "^9.0.6",
+        "eslint-plugin-storybook": "9.0.17",
         "jsonpath-plus": "^10.3.0",
         "lucide-react": "^0.475.0",
         "markdown-to-jsx": "^7.7.4",
         "next-themes": "^0.4.4",
         "platform-bible-utils": "file:../platform-bible-utils",
+        "playwright": "^1.54.1",
         "prettier": "^3.5.2",
         "prettier-plugin-jsdoc": "^1.3.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "react-hotkeys-hook": "^4.6.1",
+        "remark-cli": "^12.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-mdx": "^3.1.0",
         "sonner": "^1.7.4",
-        "storybook": "^9.0.5",
+        "storybook": "9.0.17",
+        "storybook-addon-code-editor": "^5.0.0",
+        "storybook-addon-rtl": "^2.0.0",
         "stylelint": "^16.11.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-sass-guidelines": "^12.1.0",
@@ -23190,9 +23219,10 @@
         "tslib": "^2.8.1",
         "typedoc": "^0.28.2",
         "typescript": "^5.8.3",
+        "vaul": "^1.1.2",
         "vite": "^6.3.4",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.7"
+        "vitest": "^3.2.4"
       }
     },
     "platform-bible-utils": {
@@ -23216,7 +23246,7 @@
         "typedoc": "^0.28.3",
         "typescript": "^5.8.3",
         "vite": "^6.3.4",
-        "vitest": "^3.0.7"
+        "vitest": "^3.2.4"
       }
     },
     "possible-typed-array-names": {


### PR DESCRIPTION
Roopa has seen quite a few problems that seem to be related to the extension host being stuck for long periods of time in synchronous processing from the word list. The point of this PR is to make that work asynchronous. Some code refactoring was also done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/81)
<!-- Reviewable:end -->
