### PR TITLE
fix word list dark mode

### DIFF
--- a/src/paratext-bible-word-list/src/word-list.web-view.scss
+++ b/src/paratext-bible-word-list/src/word-list.web-view.scss
@@ -1,3 +1,5 @@
+@use './tailwind';
+
 html {
   height: 100%;
 }


### PR DESCRIPTION
before:
<img width="698" height="539" alt="image" src="https://github.com/user-attachments/assets/f098e1e8-2d4e-4891-bdf5-82d80cf0eb83" />
after:
<img width="713" height="548" alt="image" src="https://github.com/user-attachments/assets/0c135a6d-1c85-44cd-bae8-b8c05a9a24ab" />

similar to https://github.com/paranext/paratext-bible-internal-extensions/pull/142

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/85)
<!-- Reviewable:end -->
