### PR TITLE
PT-3321 Properly differentiate between "loading" and "no results" in word list

### DIFF
--- a/src/paratext-bible-word-list/src/main.ts
+++ b/src/paratext-bible-word-list/src/main.ts
@@ -297,7 +297,7 @@ const wordListDataProviderEngine: IDataProviderEngine<WordListDataTypes> &
       },
       { retrieveDataImmediately: false },
     );
-    if (!bookText) return undefined;
+    if (!bookText) return [];
     this.wordList = await processBook(bookText, scrRef, scope);
     return this.wordList;
   },

--- a/src/paratext-bible-word-list/src/word-list.web-view.tsx
+++ b/src/paratext-bible-word-list/src/word-list.web-view.tsx
@@ -78,7 +78,7 @@ globalThis.webViewComponent = function WordListWebView({
         scrRef: dataSelector.scrRef,
       };
     }, [dataSelector]),
-    [],
+    undefined,
   );
 
   useEffect(() => {


### PR DESCRIPTION
Empty list == "we looked, and there are no results for you to display"
undefined == "we haven't gotten anything back yet to show you from the data provider"

The wordlist data provider needs to return an empty list when there is no book data. The component needs to default to `undefined` instead of an empty list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paratext-bible-extensions/90)
<!-- Reviewable:end -->
